### PR TITLE
Get storeconfig for use_street2_as_housenumber

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -66,7 +66,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper{
 
 		$settings = [
 					//"baseUrl"=> htmlspecialchars($baseUrl),
-					"useStreet2AsHouseNumber"=> true,
+					"useStreet2AsHouseNumber"=> (boolean)$this->_getStoreConfig('postcodenl_api/advanced_config/use_street2_as_housenumber'),
 					"useStreet3AsHouseNumberAddition"=> $this->_getConfigBoolString('postcodenl_api/advanced_config/use_street3_as_housenumber_addition'),
 					"neverHideCountry"=> $this->_getConfigBoolString('postcodenl_api/advanced_config/never_hide_country'),
 					"debug"=> False,


### PR DESCRIPTION
The field use_street2_as_housenumber is not used in de config values of Data.php. Therefore it's not used in de module and not configurable.