### PR TITLE
[FIX] - if address has an addition: first value to select is not 'false' but No housenumber addition

### DIFF
--- a/Block/Checkout/LayoutProcessor.php
+++ b/Block/Checkout/LayoutProcessor.php
@@ -174,7 +174,12 @@ class LayoutProcessor extends \Magento\Framework\View\Element\AbstractBlock impl
 				'validation' => [
 					'required-entry' => false,
 				],
-				'options' => [],
+                'options' => [
+                    [
+                        'value' => '',
+                        'label' => __('No housenumber addition'),
+                    ]
+                ],
 				'visible' => false,
                 'addressType'=> $addressType
 			],

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -45,3 +45,4 @@ Enabled,Geactiveerd
 "Use street 3 for housenumber addition","Gebruik street 3 voor huisnummer toevoeging"
 "Always show country selector","Toon altijd het land-selectie veld"
 Debug,Debug
+"No housenumber addition","Geen huisnummertoevoeging"


### PR DESCRIPTION
When an address has an addition, the default first value is empty which result in an undefined/null value as first value in the dropdown.