### PR TITLE
[BUGFIX] Postcode now written to shipping address object

### DIFF
--- a/view/frontend/web/js/view/form/postcode.js
+++ b/view/frontend/web/js/view/form/postcode.js
@@ -172,6 +172,7 @@ define([
                     registry.get(self.parentName + '.street.0').set('value', formData.street + ' ' + formData.experius_postcode_housenumber).set('error', false);
                     self.debug('address on single line');
                 }
+                registry.get(self.parentName + '.postcode').set('value',formData.experius_postcode_postcode).set('error',false);
                 this.debug('postcode or housenumber not set. ' + 'housenumber:' + formData.experius_postcode_housenumber + ' postcode:' + formData.experius_postcode_postcode);
             }
 


### PR DESCRIPTION
Issue:
When selecting manual input for postcode, the postcode field was not used in the shipping address object (this only worked for the postcode field that was filled out for automatically retrieving the address).

Fix:
When using manual input, added postcode to the fields that are used for the shipping address object