### PR TITLE
Update postcode.js

### DIFF
--- a/view/frontend/web/js/view/form/postcode.js
+++ b/view/frontend/web/js/view/form/postcode.js
@@ -245,6 +245,12 @@ define([
                     }
                 }
             });
+            
+            if (!this.getSettings().useStreet2AsHouseNumber) {
+                registry.async(self.parentName + '.experius_postcode_fieldset.experius_postcode_housenumber')(function () {
+                    registry.get(self.parentName + '.experius_postcode_fieldset.experius_postcode_housenumber').set('visible', false);
+                });
+            }
 
             this.notice('');
         },


### PR DESCRIPTION
When 'this.getSettings().useStreet2AsHouseNumber' is false and streets are set to 1 line, it means people are filling in their address in one field, so the experius housenumber field can be hidden. Experius postcode is fine, because it duplicates the value to magento postcode field. Also when 'this.getSettings().useStreet2AsHouseNumber' is false and streets are set to 1 line. And the experius is shown and used it will fill street.0 with [object object].