### PR TITLE
[BUGFIX] Fixed missing housenumbers

### DIFF
--- a/view/frontend/web/js/view/form/postcode.js
+++ b/view/frontend/web/js/view/form/postcode.js
@@ -81,6 +81,14 @@ define([
                 this.notice('')
                 this.error(null)
                 this.toggleHousenumberAdditionFields(this.getAddressData());
+                var formData = this.source.get(this.customScope);
+                if (formData.experius_postcode_housenumber) {
+                    if (this.getSettings().useStreet2AsHouseNumber) {
+                        registry.get(this.parentName + '.street.1').set('value', formData.experius_postcode_housenumber).set('error', false);
+                    } else {
+                        registry.get(this.parentName + '.street.0').set('value', formData.street + ' ' + formData.experius_postcode_housenumber).set('error', false);
+                    }
+                }
             } else if (registry.get(this.parentName + '.experius_postcode_fieldset.experius_postcode_disable').get('visible')) {
                 this.hideFields();
                 this.postcodeCheckValid = null;


### PR DESCRIPTION
When validation of postcode fails, module doesnt push the housenumber from the experius_postcode_housenumber field to the invisible housenumber field, this results in quotes without housenumber.

Added function to js observer method to also push housenumber when user switches to manual input for streetname and cityname.