### PR TITLE
Dont set region_id when it not exists in the checkout

### DIFF
--- a/view/frontend/web/js/view/form/postcode.js
+++ b/view/frontend/web/js/view/form/postcode.js
@@ -412,7 +412,9 @@ define([
                         self.debug('address on single line');
                     }
                     registry.get(self.parentName + '.country_id').set('value', 'NL').set('error', false);
-                    registry.get(self.parentName + '.region_id').set('value', response.province).set('error', false);
+                    if (typeof registry.get(self.parentName + '.region_id') !== 'undefined') {
+                        registry.get(self.parentName + '.region_id').set('value', response.province).set('error', false);
+                    }
                     registry.get(self.parentName + '.city').set('value', response.city).set('error', false);
                     registry.get(self.parentName + '.postcode').set('value', response.postcode).set('error', false);
 
@@ -537,7 +539,7 @@ define([
 
             this.previousValue = newValue;
         },
-        
+
         removeOldAdditionFromString: function (street) {
             if (this.previousValue != undefined && this.previousValue && street) {
                 var streetParts = ("" + street).split(" ");


### PR DESCRIPTION
I removed region_id from the checkout, but when filling the fields from storage this check is needed to prevent any js error.