### PR TITLE
Prevent javascript error by adding a warning

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -34,7 +34,7 @@
                 <label>Advanced Configuration</label>
                 <field id="use_street2_as_housenumber" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label" type="select" canRestore="1">
                     <label>Seperate housenumber to next street field</label>
-                    <comment/>
+                    <comment>Warning! If you set this value to 'Yes', you need to set customer/address/street_lines to a minimum of 2</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="use_street3_as_housenumber_addition" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="select" canRestore="1">


### PR DESCRIPTION
When you want to use seperate address fields but forgot to set the right number of street fields in customer/address/street_lines, you get a javascript error when filling in the form